### PR TITLE
Need HTTPS for Behance and Dribble links to work

### DIFF
--- a/Projects/Simple-Online-Store.md
+++ b/Projects/Simple-Online-Store.md
@@ -66,7 +66,7 @@ a database.
 
 ## Useful links and resources
 
-There are plenty of eCommerce Site Pages out there. You can use [Dribbble](www.dribbble.com) and [Behance](www.behance.net) for inspiration.
+There are plenty of eCommerce Site Pages out there. You can use [Dribbble](https://www.dribbble.com) and [Behance](https://www.behance.net) for inspiration.
 
 ## Example projects
 


### PR DESCRIPTION
The Behance and Dribble links were broken. Without the `https` the link will just lead to a 404.