### PR TITLE
Add example project to GitHub Status

### DIFF
--- a/Projects/GitHub-Status-App.md
+++ b/Projects/GitHub-Status-App.md
@@ -51,4 +51,4 @@ request('https://www.githubstatus.com/',  { json: true }, (err, res, body) => {
 
 ## Example projects
 
-N/a
+[Peter Luczynski's example](https://peterluczynski.github.io/github-status/)


### PR DESCRIPTION
I created this GitHub Status project, and thought I would add it, because there aren't any examples yet.