### PR TITLE
fix: Broken link for Product-Landing_page & Simple-Online-Store

### DIFF
--- a/Projects/1-Beginner/Product-Landing-Page.md
+++ b/Projects/1-Beginner/Product-Landing-Page.md
@@ -8,7 +8,7 @@ Conversion rate - the % of the visitors which purchase the product or service.
 
 When you have completed this app and the bonus features try leveling up your
 skills by expanding it to incorporate the features specified in the
-[Simple Online Store](./Simple-Online-Store.md).
+[Simple Online Store](../2-Intermediate/Simple-Online-Store.md).
 
 ## User Stories
 

--- a/Projects/2-Intermediate/Simple-Online-Store.md
+++ b/Projects/2-Intermediate/Simple-Online-Store.md
@@ -2,7 +2,7 @@
 
 **Tier:** 2-Intermediate
 
-In the [Product Landing Page](./Product-Landing-Page.md) project you implemented
+In the [Product Landing Page](../1-Beginner/Product-Landing-Page.md) project you implemented
 a landing page to provide your users with information about a product and to
 hopefully increase your sites conversion rate.
 
@@ -19,23 +19,23 @@ feel free to choose the in memory solution of your choice.
 
 ## User Stories
 
--   [ ] User can click on a 'View Products' button on the Landing Page to 
+-   [ ] User can click on a `View Products` button on the Landing Page to 
 display the Products Page.
 -   [ ] User can see a card on the Products Page for each
 Product showing the product thumbnail, name, price, a short description,
-and a 'Select' button.
--   [ ] User can see a Product Details page displayed when the 'Select' button
+and a `Select` button.
+-   [ ] User can see a Product Details page displayed when the `Select` button
 is clicked showing the same information from the product card, but also a 
-unique product id, a long description, 'Add to Cart' button, and a 
-'See More Products' button.
+unique product id, a long description, `Add to Cart` button, and a 
+`See More Products` button.
 -   [ ] User can see a confirmation message when the product is added to the
 shopping cart.
--   [ ] User can click on the 'See More Products' page to return to the 
+-   [ ] User can click on the `See More Products` page to return to the 
 Products Page. 
--   [ ] User can see a 'Shopping Cart' button on both the Landing
+-   [ ] User can see a `Shopping Cart` button on both the Landing
 Page or the Products Page. Hint:  a top bar might be a good common location
 for this button.
--   [ ] User can click on the 'Shopping Cart' button to display the Shopping
+-   [ ] User can click on the `Shopping Cart` button to display the Shopping
 Cart page containing the product id, name, price, and quantity
 ordered input box for each product previously added to the Shopping Cart.
 -   [ ] User can see a total purchase amount on the Shopping Card that is
@@ -43,13 +43,13 @@ calculated as the sum of the quantities multiplied by the unit price for each
 product ordered.
 -   [ ] User can adjust the quantity ordered for any product to adjust the
 total purchase amount. 
--   [ ] User can click a 'Place Order' button on the Shopping Cart Page to 
+-   [ ] User can click a `Place Order` button on the Shopping Cart Page to 
 complete the order. User will see a confirmation number when the order has been
 placed.
--   [ ) User can click a 'Cancel Order' button on the Shopping Cart Page to 
+-   [ ] User can click a `Cancel Order` button on the Shopping Cart Page to 
 cancel the order. User will see the product quantities and the total purchase
 amount reset to zero.
--   [ ] User can click a 'See More Products' button on the Shopping Cart Page
+-   [ ] User can click a `See More Products` button on the Shopping Cart Page
 to return to the Products Page. If the order hasn't been placed yet this will
 not clear the products that have already been added to the Products Page.
 


### PR DESCRIPTION
description: When the [commit: sort projects into folders by difficulty ](https://github.com/florinpop17/app-ideas/commit/55ac4351869d42e12486a910312e0fac7a4b350e) was merged to move files containing project description in folders depending upon their level, links for `Simple-Online-Store` on `Product-Landing-page` didn't get updated, and same vice versa.

Hence clicking on them was taking to `404` error page