### PR TITLE
fix: Project file placed in wrong folder and not mentioned in Readme

### DIFF
--- a/Projects/3-Advanced/Contribution-Tracker-App.md
+++ b/Projects/3-Advanced/Contribution-Tracker-App.md
@@ -2,7 +2,7 @@
 
 **Tier:** 3-Advanced
 
-In the [Charity Finder](./Charity-Finder-App.md) project you created an app to
+In the [Charity Finder](../2-Intermediate/Charity-Finder-App.md) project you created an app to
 help you locate a charity worthy of your contributions. Once a contribution
 has been made the goal of the Contribution Tracker app is to track it so to
 provide users with a record of all contributions for use in monitoring how

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ required to complete them.
 | [Boole Bots Game](./Projects/3-Advanced/Boole-Bot-Game.md)                | Battling Bots driven by Boolean algebra                             | 3-Advanced |
 | [Calorie Counter](./Projects/3-Advanced/Calorie-Counter-App.md)           | Calorie Counter Nutrition App                                       | 3-Advanced |
 | [Chat App](./Projects/3-Advanced/Chat-App.md)                             | Real-time chat interface                                            | 3-Advanced |
+| [Contribution Tracker App](./Projects/3-Advanced/Contribution-Tracker-App.md)                 | Track funds donated to charity                         | 3-Advanced |
 | [Elevator](./Projects/3-Advanced/Elevator-App.md)                         | Elevator simulator                                                  | 3-Advanced |
 | [Fast Food Simulator](./Projects/3-Advanced/FastFood-App.md)              | Fast Food Restaurant Simulator                                      | 3-Advanced |
 | [Instagram Clone](./Projects/3-Advanced/Instagram-Clone-App.md)           | A clone of Facebook's Instagram app                                 | 3-Advanced |


### PR DESCRIPTION
1. Contribution-Tracker-App.md file is placed in 1-Beginner folder, when it has Tier: 3-Advanced
2. The link for the Charity Finder is broken in it.
3. This project wasn't mentioned in Readme file