### PR TITLE
Update link for "MyPyramid Food Raw Data"

### DIFF
--- a/Projects/3-Advanced/Calorie-Counter-App.md
+++ b/Projects/3-Advanced/Calorie-Counter-App.md
@@ -43,7 +43,7 @@ data structure other than an array for faster searching.
 
 ## Useful links and resources
 
-[MyPyramid Food Raw Data](https://catalog.data.gov/dataset/mypyramid-food-raw-data-f9ed6)
+[MyPyramid Food Raw Data](https://healthdata.gov/dataset/mypyramid-food-raw-data)
 
 ## Example projects
 


### PR DESCRIPTION
MyPyramid Food raw data can't be currently found at https://catalog.data.gov/dataset/mypyramid-food-raw-data-f9ed6
With a quick google search I found https://healthdata.gov/dataset/mypyramid-food-raw-data which seems to have the same exact data.