### PR TITLE
Add vim swap files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.*.swp


### PR DESCRIPTION
Vim creates `.swp` temporary files that we want to ignore when doing `git status` etc.

For hacktoberfest.