### PR TITLE
Removed broken link

### DIFF
--- a/Projects/1-Beginner/Random-Meal-Generator.md
+++ b/Projects/1-Beginner/Random-Meal-Generator.md
@@ -21,4 +21,3 @@ Generate a random meal from an API.
 ## Example projects
 
 - [Random Meal Generator by Florin Pop on Codepen](https://codepen.io/FlorinPop17/full/WNeggor)
-- [Random Meal Generator by ShinSpiegel on github](https://github.com/shinspiegel/random-meal-generator)


### PR DESCRIPTION
The second example project, Random Meal Generator by ShinSpiegel on GitHub seems to be removed, since the link leads to a 404.