### PR TITLE
Removed broken link in example in Beginner Bin2Dec

### DIFF
--- a/Projects/1-Beginner/Bin2Dec-App.md
+++ b/Projects/1-Beginner/Bin2Dec-App.md
@@ -37,7 +37,6 @@ constraints:
 
 Try not to view this until you've developed your own solution:
 
--   [Binary to decimal conversion program for beginners](https://www.youtube.com/watch?v=YMIALQE26KQ)
 -   [Binary to Decimal converter using React](https://github.com/email2vimalraj/Bin2Dec)
 -   [Binary to Decimal converter with plain html, js and css](https://grfreire.github.io/Bin2Dec/)
 -   [Binary to Decimal converter using Flutter & Dart](https://github.com/israelss/AppIdeasCollection/tree/master/Tier1/Bin2Dec)


### PR DESCRIPTION
Link removed in Tier-1: Beginner Projects -> [Bin2Dec](https://github.com/florinpop17/app-ideas/blob/master/Projects/1-Beginner/Bin2Dec-App.md) -> Example projects -> [Binary to decimal conversion program for beginners](https://www.youtube.com/watch?v=YMIALQE26KQ)

<img width="802" alt="Screen Shot 2022-10-18 at 9 15 32 AM" src="https://user-images.githubusercontent.com/56205914/196440437-77a09fad-1ee5-479d-b0cb-912f18a120ec.png">
