### PR TITLE
Add .gitattributes for Markdown recognition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Markdown
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
Added the language association for MARKDOWN as every project in officially in markdown . @ issue #682  