### PR TITLE
Replaced the inactive beginner calculator links with active links

### DIFF
--- a/Projects/1-Beginner/Calculator-App.md
+++ b/Projects/1-Beginner/Calculator-App.md
@@ -58,5 +58,5 @@ number.
 - [Javascript Calculator](https://codepen.io/giana/pen/GJMBEv)
 - [React Calculator](https://codepen.io/mjijackson/pen/xOzyGX)
 - [Javascript-CALC](https://github.com/x0uter/javascript-calc)
-- [Sample Calculator](https://sevlasnog.github.io/sample-calculator)
-- [Python Calculator](https://github.com/kana800/Side-Projects/tree/master/1-Beginner/calculator)
+- [Simple Calculator](https://simple-calculator-8801.netlify.app/)
+- [Python Calculator](https://replit.com/@ShivamNikam/Calculator)


### PR DESCRIPTION
The links 'Simple Calculator' and 'Python Calculator', as seen in the changes, have been inactive for very long. The links were getting an error 404 as they were either expired or deleted by their owners. I have replaced them with the respective demonstration projects' links. If we merge this, it will be helpful for further visitors to the repository to study these projects. Thank You.