### PR TITLE
Removed "this." of function block variable

### DIFF
--- a/Projects/1-Beginner/IOT-Mailbox-App.md
+++ b/Projects/1-Beginner/IOT-Mailbox-App.md
@@ -72,7 +72,7 @@ class IOTMailbox {
       ? Math.random().toFixed(2) * -1 
       : Math.random().toFixed(2);
     console.log(`Mailbox state changed - lightLevel: ${lightLevel}`);
-    this.signalCallback(this.lightLevel);
+    this.signalCallback(lightLevel);
     this.lastLightLevel = lightLevel;
   }
 };


### PR DESCRIPTION
Had an issue with "undefined" value from the callback function. I noticed the variable that was sent was using "this" keyword so I checked the constructor and I found no variable with that name, only the local variable inside the function. 

(This is my first pull request, please provide advice as needed to help know what I need to improve for next time)