### PR TITLE
Fix typo: Reciepts → Receipts in project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ required to complete them.
 | [Podcast Directory](./Projects/2-Intermediate/Podcast-Directory-App.md)           | Directory of favorite podcasts                     | 2-Intermediate |
 | [QR Code Badge Generator](./Projects/2-Intermediate/QRCode-Badge-App.md)          | Encode badge info in a QRcode                      | 2-Intermediate |
 | [Regular Expression Helper](./Projects/2-Intermediate/RegExp-Helper-App.md)       | Test Regular Expressions                           | 2-Intermediate |
-| [Sales Reciepts App](./Projects/2-Intermediate/Sales-DB-App.md)                   | Record Sales Receipts in a DB                      | 2-Intermediate |
+| [Sales Receipts App](./Projects/2-Intermediate/Sales-DB-App.md)                   | Record Sales Receipts in a DB                      | 2-Intermediate |
 | [Simple Online Store](./Projects/2-Intermediate/Simple-Online-Store.md)           | Simple Online Store                                | 2-Intermediate |
 | [Sports Bracket Generator](./Projects/2-Intermediate/Sports-Bracket-Generator.md) | Generate a sports bracket diagram                  | 2-Intermediate |
 | [String Art](./Projects/2-Intermediate/String-Art.md)                             | An animation of moving, colored strings            | 2-Intermediate |


### PR DESCRIPTION
Fixed spelling error in Tier-2 projects list:
- Changed "Sales Reciepts App" to "Sales Receipts App"
- Improves professionalism and consistency
- Fixed typo in project name: Reciepts → Receipts

This corrects a spelling error in the Tier-2 projects list, improving the professionalism and accuracy of the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the Intermediate projects list, renaming the public-facing entry to “Sales Receipts App” for accuracy and consistency.
  * Ensures clearer naming across documentation and improves readability for users browsing project options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->