### PR TITLE
Added missing user story clarifying timer behavior for Shuffle Card Deck

### DIFF
--- a/Projects/3-Advanced/Shuffle-Deck-App.md
+++ b/Projects/3-Advanced/Shuffle-Deck-App.md
@@ -38,8 +38,8 @@ number of rounds is changed before all three tests have been run.
 the dialog with no changes.
 -   [ ] User can click the 'OK' button in the warning dialog to clear the
 output area and close the warning dialog.
-- If a user starts a new test without changing the number of rounds, the existing timers for the other tests should remain active.
-- If a user changes the number of rounds, all timers should reset and a new warning should be triggered.
+-   [ ] If a user starts a new test without changing the number of rounds, the existing timers for the other tests should remain active.
+-   [ ] If a user changes the number of rounds, all timers should reset and a new warning should be triggered.
 
 
 ## Bonus features

--- a/Projects/3-Advanced/Shuffle-Deck-App.md
+++ b/Projects/3-Advanced/Shuffle-Deck-App.md
@@ -38,7 +38,9 @@ number of rounds is changed before all three tests have been run.
 the dialog with no changes.
 -   [ ] User can click the 'OK' button in the warning dialog to clear the
 output area and close the warning dialog.
- 
+-   [ ] If a user starts a new test without changing the number of repeats, the existing timers for the other tests should remain active.
+-   [ ] If a user changes the number of repeats, all timers should reset and a new warning should be triggered.
+
 ## Bonus features
 
 -   [ ] User can see a third algorithm button - 'WELL512a.c'.

--- a/Projects/3-Advanced/Shuffle-Deck-App.md
+++ b/Projects/3-Advanced/Shuffle-Deck-App.md
@@ -38,8 +38,9 @@ number of rounds is changed before all three tests have been run.
 the dialog with no changes.
 -   [ ] User can click the 'OK' button in the warning dialog to clear the
 output area and close the warning dialog.
--   [ ] If a user starts a new test without changing the number of repeats, the existing timers for the other tests should remain active.
--   [ ] If a user changes the number of repeats, all timers should reset and a new warning should be triggered.
+- If a user starts a new test without changing the number of rounds, the existing timers for the other tests should remain active.
+- If a user changes the number of rounds, all timers should reset and a new warning should be triggered.
+
 
 ## Bonus features
 


### PR DESCRIPTION
### Description
Added missing user story to Shuffle Card Deck.

### What was added
- If a user starts a new test without changing the number of repeats, the existing timers for the other tests remain active.
- If a user changes the number of repeats, all timers reset and a new warning is triggered.

This clarifies expected behavior and resolves Issue #920.

### Tier
3-Advanced

### Checklist
- [x] I have read the contribution guidelines.
- [x] My changes are focused on this issue only.
- [x] I have checked for spelling and grammar errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified user stories for timer and warning behavior:
    * Starting a new test without changing the number of rounds keeps existing timers active for other tests.
    * Changing the number of rounds resets all timers and triggers a new warning.
  * Removed an extra blank line in the warning section formatting.
  * Confirmed no changes to Cancel/OK dialog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->